### PR TITLE
feat: add network checks and toast notifications

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
     "@openzeppelin/contracts": "^5.0.0",
     "ethers": "^6.10.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-hot-toast": "^2.4.1",
+    "i18next": "^25.4.1",
+    "react-i18next": "^15.7.2"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.3.0",

--- a/src/components/ClaimButton.jsx
+++ b/src/components/ClaimButton.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+export default function ClaimButton({ status = 'idle', label, onClick, disabled }) {
+  const isDisabled = disabled || status === 'loading';
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={isDisabled}
+      className={`relative isolate w-full rounded-2xl px-6 py-5 text-center font-medium text-white transition ${
+        isDisabled ? 'opacity-60 cursor-not-allowed' : 'hover:-translate-y-0.5 active:translate-y-0'
+      } focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300/40`}
+    >
+      <span className="absolute inset-0 -z-10 rounded-2xl bg-[#0d1110] shadow-[0_12px_24px_rgba(16,185,129,0.12)]" />
+      <span className={`pointer-events-none absolute inset-0 rounded-2xl ring-2 ${
+        isDisabled ? 'ring-emerald-400/20' : 'ring-emerald-400/40'
+      }`} />
+      {status === 'loading' && (
+        <span className="relative flex justify-center">
+          <div className="h-5 w-5 animate-spin rounded-full border-2 border-white/20 border-t-white" />
+        </span>
+      )}
+      {status === 'success' && <span className="relative">✔️</span>}
+      {status === 'idle' && <span className="relative">{label}</span>}
+    </button>
+  );
+}

--- a/src/components/InstallWallet.jsx
+++ b/src/components/InstallWallet.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+export default function InstallWallet() {
+  const { t } = useTranslation();
+  return (
+    <div className="rounded-2xl border border-white/10 bg-white/5 p-6 text-center">
+      <p className="mb-4">{t('no_wallet')}</p>
+      <a
+        href="https://metamask.io/download/"
+        target="_blank"
+        rel="noreferrer"
+        className="text-emerald-400 underline"
+      >
+        MetaMask
+      </a>
+    </div>
+  );
+}

--- a/src/hooks/useToasts.js
+++ b/src/hooks/useToasts.js
@@ -1,0 +1,16 @@
+import { toast } from 'react-hot-toast';
+import { useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+
+export default function useToasts() {
+  const { t } = useTranslation();
+
+  const showError = useCallback((code) => {
+    const msg = t(`errors.${code}`);
+    toast.error(msg || t('errors.unknown'));
+  }, [t]);
+
+  const showSuccess = useCallback((key) => toast.success(t(key)), [t]);
+
+  return { showError, showSuccess };
+}

--- a/src/hooks/useWallet.js
+++ b/src/hooks/useWallet.js
@@ -1,0 +1,72 @@
+import { useState, useEffect, useCallback } from 'react';
+import { ethers } from 'ethers';
+import { trackEvent } from '../trackEvent';
+import useToasts from './useToasts';
+
+const EXPECTED_CHAIN_ID = 1; // Ethereum mainnet by default
+
+export default function useWallet() {
+  const [provider, setProvider] = useState(null);
+  const [account, setAccount] = useState(null);
+  const [chainId, setChainId] = useState(null);
+  const [connecting, setConnecting] = useState(false);
+  const { showError } = useToasts();
+
+  const connectWallet = useCallback(async () => {
+    if (!window.ethereum) return;
+    try {
+      setConnecting(true);
+      await window.ethereum.request({ method: 'eth_requestAccounts' });
+      const prov = new ethers.BrowserProvider(window.ethereum);
+      setProvider(prov);
+      const signer = await prov.getSigner();
+      const addr = await signer.getAddress();
+      const network = await prov.getNetwork();
+      setAccount(addr);
+      setChainId(Number(network.chainId));
+      trackEvent('connect_wallet', { account: addr, chainId: Number(network.chainId) });
+    } catch (err) {
+      showError(err.code || 'unknown');
+      trackEvent('connect_fail', { code: err.code });
+    } finally {
+      setConnecting(false);
+    }
+  }, []);
+
+  const switchNetwork = useCallback(async () => {
+    if (!window.ethereum) return;
+    try {
+      await window.ethereum.request({
+        method: 'wallet_switchEthereumChain',
+        params: [{ chainId: ethers.toBeHex(EXPECTED_CHAIN_ID) }],
+      });
+      const net = await provider.getNetwork();
+      setChainId(Number(net.chainId));
+    } catch (err) {
+      showError(err.code || 'unknown');
+    }
+  }, [provider]);
+
+  useEffect(() => {
+    if (!window.ethereum) return;
+    const handleAccounts = (accs) => setAccount(accs[0]);
+    const handleChain = (id) => setChainId(Number(id));
+    window.ethereum.on('accountsChanged', handleAccounts);
+    window.ethereum.on('chainChanged', handleChain);
+    return () => {
+      window.ethereum.removeListener('accountsChanged', handleAccounts);
+      window.ethereum.removeListener('chainChanged', handleChain);
+    };
+  }, []);
+
+  return {
+    provider,
+    account,
+    chainId,
+    connecting,
+    connectWallet,
+    expectedChainId: EXPECTED_CHAIN_ID,
+    wrongNetwork: chainId != null && chainId !== EXPECTED_CHAIN_ID,
+    switchNetwork,
+  };
+}

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -1,0 +1,16 @@
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+import en from './locales/en.json';
+import pl from './locales/pl.json';
+
+i18n.use(initReactI18next).init({
+  resources: {
+    en: { translation: en },
+    pl: { translation: pl },
+  },
+  lng: 'en',
+  fallbackLng: 'en',
+  interpolation: { escapeValue: false },
+});
+
+export default i18n;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,0 +1,15 @@
+{
+  "connect_wallet": "Connect wallet",
+  "wrong_network": "Wrong network",
+  "switch_network": "Switch network",
+  "no_wallet": "Install wallet",
+  "claim": "Claim",
+  "claimed": "Claimed",
+  "errors": {
+    "user_denied": "User denied request",
+    "rejected_tx": "Transaction rejected",
+    "insufficient_gas": "Insufficient gas balance",
+    "rpc_timeout": "RPC timeout",
+    "unknown": "Unexpected error"
+  }
+}

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -1,0 +1,15 @@
+{
+  "connect_wallet": "Połącz portfel",
+  "wrong_network": "Zła sieć",
+  "switch_network": "Przełącz sieć",
+  "no_wallet": "Zainstaluj portfel",
+  "claim": "Odbierz",
+  "claimed": "Odebrano",
+  "errors": {
+    "user_denied": "Użytkownik odrzucił żądanie",
+    "rejected_tx": "Transakcja odrzucona",
+    "insufficient_gas": "Niewystarczające saldo na gaz",
+    "rpc_timeout": "Przekroczono czas RPC",
+    "unknown": "Nieznany błąd"
+  }
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,6 +2,13 @@ import React from 'react'
 import { createRoot } from 'react-dom/client'
 import App from './App.jsx'
 import './index.css'
+import './i18n'
+import { Toaster } from 'react-hot-toast'
 
 const root = createRoot(document.getElementById('root'))
-root.render(<App />)
+root.render(
+  <React.StrictMode>
+    <App />
+    <Toaster position="top-right" />
+  </React.StrictMode>
+)

--- a/src/trackEvent.js
+++ b/src/trackEvent.js
@@ -1,0 +1,3 @@
+export function trackEvent(type, data = {}) {
+  console.log('event', type, data);
+}


### PR DESCRIPTION
## Summary
- add wallet hook with network validation and switching
- show toast notifications and translations for common errors
- display contract address with copy and explorer links

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae158564bc832f87695d149db5f07e