### PR TITLE
feat: add theme switch and design tokens

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -188,6 +188,7 @@ export default function MvpTokenApp() {
   const [history, setHistory] = useState([]);
   const [historyStats, setHistoryStats] = useState({});
   const mainRef = useRef(null);
+  const [theme, setTheme] = useState("light");
 
   // mock token detail preview
   const TOTAL = 1_000_000;
@@ -218,6 +219,12 @@ export default function MvpTokenApp() {
     const stored = JSON.parse(localStorage.getItem("tc.history") || "[]");
     setHistory(stored);
   }, []);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    root.classList.remove("light", "dark");
+    root.classList.add(theme);
+  }, [theme]);
 
   const doCreate = async () => {
     if (!connected) return;
@@ -377,7 +384,7 @@ export default function MvpTokenApp() {
   };
 
   return (
-    <div className="min-h-screen bg-black text-white">
+    <div className="min-h-screen bg-background text-foreground">
       <BackgroundFX />
 
       {/* Topbar */}
@@ -390,6 +397,12 @@ export default function MvpTokenApp() {
             <div className="text-lg font-semibold tracking-tight">Token Claim</div>
           </div>
           <div className="flex items-center gap-2">
+            <button
+              onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+              className="rounded-xl border border-white/10 bg-white/10 px-3 py-1.5 text-xs text-zinc-200 transition hover:bg-white/20 focus:outline-none focus:ring-2 focus:ring-white/30"
+            >
+              {theme === "dark" ? "Light" : "Dark"} mode
+            </button>
             {mode !== "home" && (
               <button
                 className={`rounded-xl bg-white px-3 py-2 text-sm font-medium text-black shadow-sm transition hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-white/30`}

--- a/src/index.css
+++ b/src/index.css
@@ -2,9 +2,14 @@
 @tailwind components;
 @tailwind utilities;
 
-:root {
-  color-scheme: dark;
-}
-body {
-  @apply text-white bg-black;
+@layer base {
+  .light {
+    color-scheme: light;
+  }
+  .dark {
+    color-scheme: dark;
+  }
+  body {
+    @apply bg-background text-foreground;
+  }
 }

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,0 +1,24 @@
+export const theme = {
+  typography: {
+    'text-xs': '0.75rem',
+    'text-sm': '0.875rem',
+    'text-lg': '1.125rem',
+  },
+  spacing: {
+    s4: '4px',
+    s8: '8px',
+    s12: '12px',
+    s16: '16px',
+  },
+  radius: {
+    md: '0.375rem',
+    xl: '0.75rem',
+  },
+  shadows: {
+    sm: '0 1px 2px rgba(0,0,0,0.05)',
+    md: '0 4px 6px -1px rgba(0,0,0,0.1)',
+    lg: '0 10px 15px -3px rgba(0,0,0,0.1)',
+  },
+};
+
+export default theme;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,8 +1,47 @@
 /** @type {import('tailwindcss').Config} */
 export default {
   content: ["./index.html", "./src/**/*.{js,jsx,ts,tsx}"],
+  darkMode: "class",
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        background: "rgb(var(--color-bg) / <alpha-value>)",
+        foreground: "rgb(var(--color-fg) / <alpha-value>)",
+      },
+      fontSize: {
+        xs: "0.75rem",
+        sm: "0.875rem",
+        lg: "1.125rem",
+      },
+      spacing: {
+        s4: "4px",
+        s8: "8px",
+        s12: "12px",
+        s16: "16px",
+      },
+      borderRadius: {
+        md: "0.375rem",
+        xl: "0.75rem",
+      },
+      boxShadow: {
+        sm: "0 1px 2px 0 rgba(0,0,0,0.05)",
+        md: "0 4px 6px -1px rgba(0,0,0,0.1)",
+        lg: "0 10px 15px -3px rgba(0,0,0,0.1)",
+      },
+    },
   },
-  plugins: [],
+  plugins: [
+    function ({ addBase }) {
+      addBase({
+        ":root, .light": {
+          "--color-bg": "255 255 255",
+          "--color-fg": "0 0 0",
+        },
+        ".dark": {
+          "--color-bg": "0 0 0",
+          "--color-fg": "255 255 255",
+        },
+      });
+    },
+  ],
 }


### PR DESCRIPTION
## Summary
- add design token definitions for typography, spacing, radius and shadows
- extend Tailwind config with CSS variables and custom theme values
- wire global light/dark theme support with toggle button

## Testing
- `npm test` *(fails: Missing script "test"?)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b32ae5a580832fbcbb11038e5860bb