### PR TITLE
feat: add token summary component

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,7 @@ import React, { useMemo, useState, useEffect, useRef } from "react";
 import { ethers } from "ethers";
 import ClaimableToken from "./ClaimableToken.json";
 import NetworkBadge from "./components/NetworkBadge.jsx";
+import TokenSummary from "./components/TokenSummary.jsx";
 
 // MVP single-file UI mock (no blockchain wired yet)
 // Tailwind only. Dark theme, simple modern buttons.
@@ -548,31 +549,13 @@ export default function MvpTokenApp() {
               </button>
             </div>
 
-            <div className="flex items-start gap-4">
-              {/* Logo render */}
-              <div className="mt-1 flex h-14 w-14 items:center justify-center rounded-2xl border border-white/10 bg-white/5 shadow-sm">
-                {sampleToken.logoId === 0 && (
-                  <div className="h-8 w-8 rounded-full bg-gradient-to-br from-zinc-300 to-zinc-500" />
-                )}
-                {sampleToken.logoId === 1 && (
-                  <div className="h-8 w-8 rotate-45 rounded-lg bg-gradient-to-br from-zinc-400 to-zinc-700" />
-                )}
-                {sampleToken.logoId === 2 && (
-                  <div className="h-8 w-8 bg-[conic-gradient(at_50%_50%,#a1a1aa,#52525b,#a1a1aa)] rounded-full" />
-                )}
-              </div>
-
-              <div className="flex-1">
-                <div className="flex flex-wrap items-center gap-2">
-                  <h3 className="text-lg font-semibold">{sampleToken.name}</h3>
-                  <span className="rounded-full border border-white/10 bg-white/5 px-2 py-0.5 text-xs text-zinc-200">
-                    {sampleToken.symbol}
-                  </span>
-                </div>
-                <div className="mt-1 text-sm text-zinc-300">{sampleToken.description}</div>
-                <div className="mt-2 text-xs text-zinc-400">Author: {sampleToken.author}</div>
-              </div>
-            </div>
+            <TokenSummary
+              tokenAddress={tokenAddress}
+              name={sampleToken.name}
+              symbol={sampleToken.symbol}
+              progress={Math.round(((TOTAL - remaining) / TOTAL) * 100)}
+              chainId={chainId}
+            />
 
             <div className="mt-6 grid gap-4 md:grid-cols-3">
               <Stat label="Remaining pool" value={remaining.toLocaleString()} hint="out of 1,000,000" />

--- a/src/components/TokenSummary.jsx
+++ b/src/components/TokenSummary.jsx
@@ -1,0 +1,78 @@
+import React from "react";
+import NetworkBadge from "./NetworkBadge.jsx";
+
+const EXPLORERS = {
+  1: "https://etherscan.io",
+  5: "https://goerli.etherscan.io",
+  10: "https://optimistic.etherscan.io",
+  56: "https://bscscan.com",
+  97: "https://testnet.bscscan.com",
+  137: "https://polygonscan.com",
+  420: "https://goerli-optimism.etherscan.io",
+  42161: "https://arbiscan.io",
+  421613: "https://goerli.arbiscan.io",
+  11155111: "https://sepolia.etherscan.io",
+};
+
+export default function TokenSummary({ tokenAddress, name, symbol, progress = 0, chainId }) {
+  const explorerBase = chainId ? EXPLORERS[Number(chainId)] : null;
+
+  const handleCopy = () => {
+    if (tokenAddress) {
+      navigator?.clipboard?.writeText(tokenAddress);
+    }
+  };
+
+  const shortAddr = tokenAddress ? `${tokenAddress.slice(0, 6)}…${tokenAddress.slice(-4)}` : "";
+
+  return (
+    <div className="flex flex-col gap-3 rounded-2xl border border-white/10 bg-white/5 p-4">
+      <div className="flex items-center justify-between">
+        <div className="flex flex-wrap items-center gap-2">
+          <h3 className="text-lg font-semibold">{name}</h3>
+          {symbol && (
+            <span className="rounded-full border border-white/10 bg-white/5 px-2 py-0.5 text-xs text-zinc-200">
+              {symbol}
+            </span>
+          )}
+        </div>
+        {chainId && <NetworkBadge chainId={chainId} />}
+      </div>
+
+      {tokenAddress && (
+        <div className="flex items-center gap-2 text-xs text-zinc-400">
+          <span>{shortAddr}</span>
+          <button
+            onClick={handleCopy}
+            className="rounded border border-white/10 bg-white/10 px-2 py-0.5 text-xs text-zinc-200 transition hover:bg-white/20 focus:outline-none focus:ring-2 focus:ring-white/30"
+          >
+            Copy
+          </button>
+          {explorerBase && (
+            <a
+              href={`${explorerBase}/address/${tokenAddress}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-emerald-400 hover:underline"
+            >
+              Explorer
+            </a>
+          )}
+        </div>
+      )}
+
+      <div className="mt-2">
+        <div className="mb-1 flex items-center justify-between text-xs text-zinc-400">
+          <span>Progress</span>
+          <span>{progress}%</span>
+        </div>
+        <div className="h-2 w-full overflow-hidden rounded-full bg-white/10">
+          <div
+            className="h-full rounded-full bg-gradient-to-r from-emerald-400 to-indigo-400"
+            style={{ width: `${Math.min(100, Math.max(0, progress))}%` }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `TokenSummary` component with progress bar, copy address, and explorer link
- integrate `TokenSummary` into claim view

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b32d92293c832f9212d8d6581c96cb