### PR TITLE
Add eligibility info component to claim view

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,7 @@ import { ethers } from "ethers";
 import ClaimableToken from "./ClaimableToken.json";
 import NetworkBadge from "./components/NetworkBadge.jsx";
 import TokenSummary from "./components/TokenSummary.jsx";
+import EligibilityInfo from "./components/EligibilityInfo.jsx";
 
 // MVP single-file UI mock (no blockchain wired yet)
 // Tailwind only. Dark theme, simple modern buttons.
@@ -378,6 +379,7 @@ export default function MvpTokenApp() {
   }, []);
 
   const claimedSoFar = Math.max(0, TOTAL - remaining);
+  const eligibleAmount = remaining >= 100 ? 100 : remaining;
 
   const connectWallet = async () => {
     if (!window.ethereum) {
@@ -557,6 +559,11 @@ export default function MvpTokenApp() {
               chainId={chainId}
             />
 
+            <EligibilityInfo
+              status={remaining > 0 ? "eligible" : "not eligible"}
+              eligibleAmount={eligibleAmount}
+            />
+
             <div className="mt-6 grid gap-4 md:grid-cols-3">
               <Stat label="Remaining pool" value={remaining.toLocaleString()} hint="out of 1,000,000" />
               <Stat label="Claim per tx" value="100" />
@@ -571,7 +578,7 @@ export default function MvpTokenApp() {
               <div className="text-xs text-zinc-400">
                 {tokenAddress ? `Token contract: ${tokenAddress}` : "Contract address will appear after deployment"}
               </div>
-              <CtaButton label={remaining > 0 ? (remaining >= 100 ? "Claim 100" : `Claim ${remaining}`) : "Pool empty"} onClick={doClaim} disabled={!connected || remaining === 0} />
+              <CtaButton label={remaining > 0 ? `Claim ${eligibleAmount}` : "Pool empty"} onClick={doClaim} disabled={!connected || remaining === 0} />
             </div>
 
             {!connected && (

--- a/src/components/EligibilityInfo.jsx
+++ b/src/components/EligibilityInfo.jsx
@@ -1,0 +1,10 @@
+import React from "react";
+
+export default function EligibilityInfo({ status, eligibleAmount }) {
+  return (
+    <div className="mt-6 rounded-2xl border border-white/10 bg-white/5 p-4">
+      <div className="text-sm text-zinc-300">Status: {status}</div>
+      <div className="mt-1 text-sm text-zinc-300">Eligible amount: {eligibleAmount}</div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- compute `eligibleAmount` in App to determine available claim amount
- introduce `EligibilityInfo` component to display claim eligibility details
- show eligibility info below token summary in claim screen

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b32e979384832f8821a4a14e5d769c