### PR TITLE
feat: display identicon and tooltip for connected address

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@openzeppelin/contracts": "^5.0.0",
+    "ethereum-blockies": "^0.1.1",
     "ethers": "^6.10.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,7 @@ import React, { useMemo, useState, useEffect, useRef } from "react";
 import { ethers } from "ethers";
 import ClaimableToken from "./ClaimableToken.json";
 import NetworkBadge from "./components/NetworkBadge.jsx";
+import AddressBadge from "./components/AddressBadge.jsx";
 import TokenSummary from "./components/TokenSummary.jsx";
 import EligibilityInfo from "./components/EligibilityInfo.jsx";
 import CtaButton from "./components/CtaButton.jsx";
@@ -433,19 +434,19 @@ export default function MvpTokenApp() {
             {mode !== "home" && (
               <>
                 {connected && chainId && <NetworkBadge chainId={chainId} />}
-                <button
-                  className={`rounded-xl bg-white px-3 py-2 text-sm font-medium text-black shadow-sm transition hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-white/30`}
-                  onClick={!connected ? connectWallet : undefined}
-                  aria-label={
-                    connected && account
-                      ? `Connected wallet ${account.slice(0, 6)}…${account.slice(-4)}`
-                      : "Connect wallet"
-                  }
-                  role="button"
-                  tabIndex={0}
-                >
-                  {connected && account ? `${account.slice(0, 6)}…${account.slice(-4)}` : "Connect wallet"}
-                </button>
+                {connected && account ? (
+                  <AddressBadge address={account} chainId={chainId} />
+                ) : (
+                  <button
+                    className={`rounded-xl bg-white px-3 py-2 text-sm font-medium text-black shadow-sm transition hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-white/30`}
+                    onClick={connectWallet}
+                    aria-label="Connect wallet"
+                    role="button"
+                    tabIndex={0}
+                  >
+                    Connect wallet
+                  </button>
+                )}
               </>
             )}
           </div>

--- a/src/components/AddressBadge.jsx
+++ b/src/components/AddressBadge.jsx
@@ -1,0 +1,55 @@
+import React, { useMemo, useState, useEffect } from "react";
+import { ethers } from "ethers";
+import blockies from "ethereum-blockies";
+
+const LABELS = {
+  1: "Ethereum",
+  5: "Goerli",
+  10: "Optimism",
+  56: "BSC",
+  97: "BSC Testnet",
+  137: "Polygon",
+  420: "Optimism Goerli",
+  42161: "Arbitrum",
+  421613: "Arbitrum Goerli",
+  11155111: "Sepolia",
+};
+
+export default function AddressBadge({ address, chainId }) {
+  const [gasPrice, setGasPrice] = useState(null);
+
+  useEffect(() => {
+    if (!chainId || !window.ethereum) return;
+    const provider = new ethers.BrowserProvider(window.ethereum);
+    provider.getFeeData().then((fee) => {
+      if (fee.gasPrice) {
+        const gwei = Number(fee.gasPrice) / 1e9;
+        setGasPrice(gwei);
+      }
+    });
+  }, [chainId]);
+
+  const identicon = useMemo(() => {
+    if (!address) return null;
+    return blockies.create({ seed: address.toLowerCase(), size: 8, scale: 4 }).toDataURL();
+  }, [address]);
+
+  if (!address) return null;
+
+  const network = LABELS[Number(chainId)] || (chainId ? `Chain ${chainId}` : "");
+  const title = `Address: ${address}\n${network ? `Network: ${network}\n` : ""}${
+    gasPrice != null ? `Gas: ${gasPrice.toFixed(2)} gwei` : ""
+  }`.trim();
+
+  return (
+    <span
+      className="flex items-center gap-2 rounded-xl border border-white/10 bg-white/10 px-3 py-1.5 text-xs text-zinc-200"
+      title={title}
+    >
+      {identicon && <img src={identicon} alt="identicon" className="h-6 w-6 rounded" />}
+      <span>
+        {address.slice(0, 6)}…{address.slice(-4)}
+      </span>
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary
- add AddressBadge component rendering an identicon and tooltip with network and gas details
- replace text address in the top bar with AddressBadge and add ethereum-blockies dependency

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b338dfe6dc832fb2dbf7f79c7dfaf3