### PR TITLE
Add recent activity and claims table to claim view

### DIFF
--- a/src/components/ClaimsTable.jsx
+++ b/src/components/ClaimsTable.jsx
@@ -1,0 +1,97 @@
+import React, { useState, useMemo } from "react";
+
+function shorten(addr) {
+  return addr ? `${addr.slice(0, 6)}…${addr.slice(-4)}` : "";
+}
+
+export default function ClaimsTable({ claims = [] }) {
+  const [sortConfig, setSortConfig] = useState({ key: "time", direction: "desc" });
+  const [page, setPage] = useState(1);
+  const pageSize = 10;
+
+  const sortedClaims = useMemo(() => {
+    const sorted = [...claims];
+    if (sortConfig.key) {
+      sorted.sort((a, b) => {
+        const aVal = a[sortConfig.key];
+        const bVal = b[sortConfig.key];
+        if (aVal < bVal) return sortConfig.direction === "asc" ? -1 : 1;
+        if (aVal > bVal) return sortConfig.direction === "asc" ? 1 : -1;
+        return 0;
+      });
+    }
+    return sorted;
+  }, [claims, sortConfig]);
+
+  const totalPages = Math.max(1, Math.ceil(sortedClaims.length / pageSize));
+  const pageData = sortedClaims.slice((page - 1) * pageSize, page * pageSize);
+
+  const requestSort = (key) => {
+    setSortConfig((prev) => {
+      let direction = "asc";
+      if (prev.key === key && prev.direction === "asc") direction = "desc";
+      return { key, direction };
+    });
+  };
+
+  const sortIndicator = (key) => {
+    if (sortConfig.key !== key) return "";
+    return sortConfig.direction === "asc" ? "↑" : "↓";
+    };
+
+  return (
+    <div className="mt-6">
+      <table className="min-w-full text-sm">
+        <thead>
+          <tr className="text-left text-zinc-300">
+            <th className="cursor-pointer px-2 py-1" onClick={() => requestSort("address")}>
+              Address {sortIndicator("address")}
+            </th>
+            <th className="cursor-pointer px-2 py-1" onClick={() => requestSort("amount")}>
+              Amount {sortIndicator("amount")}
+            </th>
+            <th className="cursor-pointer px-2 py-1" onClick={() => requestSort("time")}>
+              Time {sortIndicator("time")}
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {pageData.length === 0 ? (
+            <tr>
+              <td colSpan="3" className="py-4 text-center text-zinc-400">
+                No claims.
+              </td>
+            </tr>
+          ) : (
+            pageData.map((c, idx) => (
+              <tr key={idx} className="border-t border-white/10">
+                <td className="px-2 py-2 font-mono">{shorten(c.address)}</td>
+                <td className="px-2 py-2">{c.amount}</td>
+                <td className="px-2 py-2">{new Date(c.time).toLocaleString()}</td>
+              </tr>
+            ))
+          )}
+        </tbody>
+      </table>
+      <div className="mt-4 flex items-center justify-between text-sm text-zinc-200">
+        <button
+          onClick={() => setPage((p) => Math.max(1, p - 1))}
+          disabled={page === 1}
+          className="rounded border border-white/10 bg-white/10 px-3 py-1.5 disabled:opacity-50"
+        >
+          Previous
+        </button>
+        <span className="text-zinc-400">
+          Page {page} / {totalPages}
+        </span>
+        <button
+          onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+          disabled={page === totalPages}
+          className="rounded border border-white/10 bg-white/10 px-3 py-1.5 disabled:opacity-50"
+        >
+          Next
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/RecentActivity.jsx
+++ b/src/components/RecentActivity.jsx
@@ -1,0 +1,39 @@
+import React from "react";
+
+function shorten(addr) {
+  return addr ? `${addr.slice(0, 6)}…${addr.slice(-4)}` : "";
+}
+
+function relativeTime(ts) {
+  const diff = Math.floor((Date.now() - ts) / 1000);
+  if (diff < 60) return `${diff}s ago`;
+  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
+  return `${Math.floor(diff / 86400)}d ago`;
+}
+
+export default function RecentActivity({ claims = [] }) {
+  const items = [...claims].sort((a, b) => b.time - a.time).slice(0, 5);
+
+  if (items.length === 0) {
+    return <div className="mt-6 text-sm text-zinc-400">No recent activity.</div>;
+  }
+
+  return (
+    <div className="mt-6">
+      <h3 className="mb-2 text-lg font-semibold">Recent Activity</h3>
+      <ul className="space-y-2 text-sm text-zinc-200">
+        {items.map((tx, idx) => (
+          <li
+            key={idx}
+            className="flex items-center justify-between rounded-lg border border-white/10 bg-white/5 px-3 py-2"
+          >
+            <span className="font-mono">{shorten(tx.address)}</span>
+            <span>{tx.amount}</span>
+            <span className="text-xs text-zinc-400">{relativeTime(tx.time)}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `RecentActivity` component displaying up to five latest claims
- introduce `ClaimsTable` with sortable columns and pagination
- wire new components into claim view with tabbed navigation and tracking of claim records

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Rollup failed to resolve import "react-hot-toast")*

------
https://chatgpt.com/codex/tasks/task_e_68b33b44ebb8832fa85f2e57bae08c41