### PR TITLE
feat: add theme toggle with persistent dark mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,11 +1,18 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="light">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Token Claim MVP</title>
+    <script>
+      const storedTheme = localStorage.getItem("tc.theme");
+      if (storedTheme === "dark" || storedTheme === "light") {
+        document.documentElement.classList.remove("light", "dark");
+        document.documentElement.classList.add(storedTheme);
+      }
+    </script>
   </head>
-  <body class="min-h-screen bg-black">
+  <body class="min-h-screen bg-background text-foreground">
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -36,8 +36,10 @@ function LogoSwatch({ id, selected, onSelect, label, className = "" }) {
       type="button"
       onClick={() => onSelect(id)}
       className={`group relative flex h-16 w-16 items-center justify-center rounded-2xl border transition-all ${
-        selected ? "border-emerald-400 ring-4 ring-emerald-400/20" : "border-white/15 hover:border-white/30"
-      } focus:outline-none focus:ring-2 focus:ring-white/30 ${className}`}
+        selected
+          ? "border-emerald-400 ring-4 ring-emerald-400/20"
+          : "border-black/15 hover:border-black/30 dark:border-white/15 dark:hover:border-white/30"
+      } focus:outline-none focus:ring-2 focus:ring-black/30 dark:focus:ring-white/30 ${className}`}
       aria-pressed={selected}
       aria-label={`Select logo ${label}`}
       role="button"
@@ -55,17 +57,17 @@ function LogoSwatch({ id, selected, onSelect, label, className = "" }) {
           <div className="h-8 w-8 bg-[conic-gradient(at_50%_50%,#a1a1aa,#52525b,#a1a1aa)] rounded-full" />
         )}
       </div>
-      <span className="absolute -bottom-6 text-xs text-zinc-300">{label}</span>
+      <span className="absolute -bottom-6 text-xs text-zinc-700 dark:text-zinc-300">{label}</span>
     </button>
   );
 }
 
 function Stat({ label, value, hint }) {
   return (
-    <div className="rounded-2xl border border-white/10 bg-white/5 p-4 shadow-[0_0_0_1px_rgba(255,255,255,0.02)] backdrop-blur">
-      <div className="text-sm text-zinc-300">{label}</div>
-      <div className="mt-1 text-2xl font-semibold tracking-tight text-white">{value}</div>
-      {hint && <div className="mt-1 text-xs text-zinc-400">{hint}</div>}
+    <div className="rounded-2xl border border-black/10 bg-black/5 p-4 shadow-[0_0_0_1px_rgba(255,255,255,0.02)] backdrop-blur dark:border-white/10 dark:bg-white/5">
+      <div className="text-sm text-zinc-700 dark:text-zinc-300">{label}</div>
+      <div className="mt-1 text-2xl font-semibold tracking-tight text-black dark:text-white">{value}</div>
+      {hint && <div className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">{hint}</div>}
     </div>
   );
 }
@@ -75,17 +77,17 @@ function Progress({ total, remaining }) {
   const pct = Math.min(100, Math.round((claimed / total) * 100));
   return (
     <div>
-      <div className="mb-2 flex items-center justify-between text-sm text-zinc-300">
+      <div className="mb-2 flex items-center justify-between text-sm text-zinc-700 dark:text-zinc-300">
         <span>Claim progress</span>
         <span>{pct}%</span>
       </div>
-      <div className="h-3 w-full overflow-hidden rounded-full bg-white/10">
+      <div className="h-3 w-full overflow-hidden rounded-full bg-black/10 dark:bg-white/10">
         <div
           className="h-full rounded-full bg-gradient-to-r from-emerald-400 to-indigo-400 transition-all"
           style={{ width: `${pct}%` }}
         />
       </div>
-      <div className="mt-2 text-xs text-zinc-400">
+      <div className="mt-2 text-xs text-zinc-500 dark:text-zinc-400">
         {claimed.toLocaleString()} / {total.toLocaleString()} tokens claimed
       </div>
     </div>
@@ -129,20 +131,20 @@ function relativeTime(ts) {
 
 function HistoryItem({ item, stats, onRefresh }) {
   return (
-    <div className="rounded-2xl border border-white/10 bg-white/5 p-4">
+    <div className="rounded-2xl border border-black/10 bg-black/5 p-4 dark:border-white/10 dark:bg-white/5">
       <div className="flex items-start justify-between gap-4">
         <div>
           <div className="font-semibold">
             {item.name} / {item.symbol}
           </div>
-          <div className="mt-1 text-xs text-zinc-400">
+          <div className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
             Token {shorten(item.token)} • Pool {shorten(item.pool)} • Chain {item.chainId}
           </div>
-          <div className="mt-1 text-xs text-zinc-400">{relativeTime(item.createdAt)}</div>
+          <div className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">{relativeTime(item.createdAt)}</div>
         </div>
           <button
             onClick={onRefresh}
-            className="rounded-xl border border-white/10 bg-white/10 px-3 py-1 text-xs text-zinc-200 transition hover:bg-white/20 focus:outline-none focus:ring-2 focus:ring-white/30"
+            className="rounded-xl border border-black/10 bg-black/10 px-3 py-1 text-xs text-zinc-700 transition hover:bg-black/20 focus:outline-none focus:ring-2 focus:ring-black/30 dark:border-white/10 dark:bg-white/10 dark:text-zinc-200 dark:hover:bg-white/20 dark:focus:ring-white/30"
             aria-label="Refresh"
             role="button"
             tabIndex={0}
@@ -192,15 +194,15 @@ function SegmentedControl() {
 
   return (
     <div className="mb-6 w-full">
-      <div className="flex w-full flex-col rounded-xl border border-white/10 bg-white/5 p-1 xl:flex-row">
+      <div className="flex w-full flex-col rounded-xl border border-black/10 bg-black/5 p-1 xl:flex-row dark:border-white/10 dark:bg-white/5">
         {items.map((item) => (
           <button
             key={item.id}
             onClick={() => handleClick(item.id)}
             className={`w-full rounded-lg px-4 py-2 text-sm transition xl:flex-1 ${
               active === item.id
-                ? "bg-white/20 text-white"
-                : "text-zinc-400 hover:bg-white/10"
+                ? "bg-black/20 text-black dark:bg-white/20 dark:text-white"
+                : "text-zinc-600 hover:bg-black/10 dark:text-zinc-400 dark:hover:bg-white/10"
             }`}
           >
             {item.label}
@@ -224,7 +226,7 @@ export default function MvpTokenApp() {
   const [tokenAddress, setTokenAddress] = useState(null);
   const [history, setHistory] = useState([]);
   const [historyStats, setHistoryStats] = useState({});
-  const [theme, setTheme] = useState("light");
+  const [theme, setTheme] = useState(() => localStorage.getItem("tc.theme") || "light");
 
   // mock token detail preview
   const TOTAL = 1_000_000;
@@ -258,6 +260,7 @@ export default function MvpTokenApp() {
     const root = document.documentElement;
     root.classList.remove("light", "dark");
     root.classList.add(theme);
+    localStorage.setItem("tc.theme", theme);
   }, [theme]);
 
   const doCreate = async () => {
@@ -444,10 +447,10 @@ export default function MvpTokenApp() {
       <BackgroundFX />
 
       {/* Topbar */}
-      <header className="sticky top-0 z-20 border-b border-white/10 bg-black/40 backdrop-blur">
+      <header className="sticky top-0 z-20 border-b border-black/10 bg-white/40 backdrop-blur dark:border-white/10 dark:bg-black/40">
         <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-4">
           <div className="flex items-center gap-3">
-            <div className="flex h-9 w-9 items-center justify-center rounded-2xl bg-white/10 text-white shadow-inner">
+            <div className="flex h-9 w-9 items-center justify-center rounded-2xl bg-black/10 text-black shadow-inner dark:bg-white/10 dark:text-white">
               <span className="text-sm font-bold">MVP</span>
             </div>
             <div className="text-lg font-semibold tracking-tight">Token Claim</div>
@@ -455,7 +458,7 @@ export default function MvpTokenApp() {
           <div className="flex items-center gap-2">
             <NetworkBadge chainId={chainId} />
             <button
-              className={`rounded-xl bg-white px-3 py-2 text-sm font-medium text-black shadow-sm transition hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-white/30`}
+              className={`rounded-xl bg-black px-3 py-2 text-sm font-medium text-white shadow-sm transition hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-black/30 dark:bg-white dark:text-black dark:focus:ring-white/30`}
               onClick={connectWallet}
               aria-label="Connect wallet"
               role="button"
@@ -465,7 +468,7 @@ export default function MvpTokenApp() {
             </button>
             <button
               onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
-              className="rounded-xl border border-white/10 bg-white/10 px-3 py-1.5 text-xs text-zinc-200 transition hover:bg-white/20 focus:outline-none focus:ring-2 focus:ring-white/30"
+              className="rounded-xl border border-black/10 bg-black/10 px-3 py-1.5 text-xs text-zinc-700 transition hover:bg-black/20 focus:outline-none focus:ring-2 focus:ring-black/30 dark:border-white/10 dark:bg-white/10 dark:text-zinc-200 dark:hover:bg-white/20 dark:focus:ring-white/30"
               aria-label="Toggle theme"
               role="button"
               tabIndex={0}
@@ -478,25 +481,28 @@ export default function MvpTokenApp() {
       <main className="mx-auto max-w-7xl px-4 pb-16">
         <SegmentedControl />
         <div className="grid grid-cols-1 gap-6 xl:grid-cols-12">
-          <section id="create" className="rounded-2xl border border-white/10 bg-white/5 p-6 shadow-xl backdrop-blur xl:col-span-4">
+          <section
+            id="create"
+            className="rounded-2xl border border-black/10 bg-black/5 p-6 shadow-xl backdrop-blur dark:border-white/10 dark:bg-white/5 xl:col-span-4"
+          >
             <div className="mb-4">
               <h2 className="text-xl font-semibold">Create token</h2>
             </div>
 
             <div className="grid gap-4">
               <div>
-                <label className="mb-1 block text-sm text-zinc-300">Name *</label>
+                <label className="mb-1 block text-sm text-zinc-700 dark:text-zinc-300">Name *</label>
                 <input
-                  className="w-full rounded-xl border border-white/10 bg-black/40 px-3 py-2 text-white outline-none placeholder:text-zinc-500 focus:ring-2 focus:ring-emerald-400/30"
+                  className="w-full rounded-xl border border-black/10 bg-white px-3 py-2 text-black outline-none placeholder:text-zinc-400 focus:ring-2 focus:ring-emerald-400/30 dark:border-white/10 dark:bg-black/40 dark:text-white dark:placeholder:text-zinc-500"
                   placeholder="e.g. WalkCoin"
                   value={name}
                   onChange={(e) => setName(e.target.value)}
                 />
               </div>
               <div>
-                <label className="mb-1 block text-sm text-zinc-300">Symbol *</label>
+                <label className="mb-1 block text-sm text-zinc-700 dark:text-zinc-300">Symbol *</label>
                 <input
-                  className="w-full rounded-xl border border-white/10 bg-black/40 px-3 py-2 uppercase text-white outline-none placeholder:text-zinc-500 focus:ring-2 focus:ring-emerald-400/30"
+                  className="w-full rounded-xl border border-black/10 bg-white px-3 py-2 uppercase text-black outline-none placeholder:text-zinc-400 focus:ring-2 focus:ring-emerald-400/30 dark:border-white/10 dark:bg-black/40 dark:text-white dark:placeholder:text-zinc-500"
                   placeholder="e.g. WLK"
                   value={symbol}
                   onChange={(e) => setSymbol(e.target.value.slice(0, 11))}
@@ -504,16 +510,16 @@ export default function MvpTokenApp() {
               </div>
               <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-2">
                 <div>
-                  <label className="mb-1 block text-sm text-zinc-300">Author *</label>
+                  <label className="mb-1 block text-sm text-zinc-700 dark:text-zinc-300">Author *</label>
                   <input
-                    className="w-full rounded-xl border border-white/10 bg-black/40 px-3 py-2 text-white outline-none placeholder:text-zinc-500 focus:ring-2 focus:ring-emerald-400/30"
+                    className="w-full rounded-xl border border-black/10 bg-white px-3 py-2 text-black outline-none placeholder:text-zinc-400 focus:ring-2 focus:ring-emerald-400/30 dark:border-white/10 dark:bg-black/40 dark:text-white dark:placeholder:text-zinc-500"
                     placeholder="Your name or address"
                     value={author}
                     onChange={(e) => setAuthor(e.target.value)}
                   />
                 </div>
                 <div>
-                  <label className="mb-1 block text-sm text-zinc-300">Logo *</label>
+                  <label className="mb-1 block text-sm text-zinc-700 dark:text-zinc-300">Logo *</label>
                   <div className="flex items-end gap-6 pt-1">
                     <LogoSwatch id={0} label="A" selected={logoId === 0} onSelect={setLogoId} />
                     <LogoSwatch id={1} label="B" selected={logoId === 1} onSelect={setLogoId} />
@@ -522,9 +528,9 @@ export default function MvpTokenApp() {
                 </div>
               </div>
               <div>
-                <label className="mb-1 block text-sm text-zinc-300">Description *</label>
+                <label className="mb-1 block text-sm text-zinc-700 dark:text-zinc-300">Description *</label>
                 <textarea
-                  className="min-h-[96px] w-full rounded-xl border border-white/10 bg-black/40 px-3 py-2 text-white outline-none placeholder:text-zinc-500 focus:ring-2 focus:ring-emerald-400/30"
+                  className="min-h-[96px] w-full rounded-xl border border-black/10 bg-white px-3 py-2 text-black outline-none placeholder:text-zinc-400 focus:ring-2 focus:ring-emerald-400/30 dark:border-white/10 dark:bg-black/40 dark:text-white dark:placeholder:text-zinc-500"
                   placeholder="Short description of the token and its purpose…"
                   value={description}
                   onChange={(e) => setDescription(e.target.value)}
@@ -536,37 +542,42 @@ export default function MvpTokenApp() {
             <div className="mt-8 grid gap-4 sm:grid-cols-2 md:grid-cols-3">
               <Stat label="Claimed by others" value={claimedSoFar.toLocaleString()} hint={`out of ${TOTAL.toLocaleString()}`} />
               <Stat label="Claim count" value={claimedCount.toLocaleString()} />
-              <div className="rounded-2xl border border-white/10 bg-white/5 p-4">
-                <div className="text-sm text-zinc-300">Claim activity</div>
+              <div className="rounded-2xl border border-black/10 bg-black/5 p-4 dark:border-white/10 dark:bg-white/5">
+                <div className="text-sm text-zinc-700 dark:text-zinc-300">Claim activity</div>
                 <div className="mt-2">
                   {claimHistory.length > 0 ? (
                     <SimpleSparkline data={claimHistory} max={TOTAL} />
                   ) : (
-                    <div className="text-xs text-zinc-400">No claims yet</div>
+                    <div className="text-xs text-zinc-500 dark:text-zinc-400">No claims yet</div>
                   )}
                 </div>
               </div>
             </div>
 
             <div className="mt-6 flex items-center justify-between">
-              <div className="text-xs text-zinc-400">Supply: 1,000,000 • Claim reward: 100</div>
+              <div className="text-xs text-zinc-500 dark:text-zinc-400">Supply: 1,000,000 • Claim reward: 100</div>
               <CtaButton label="Create token" onClick={doCreate} disabled={!connected || !formValid} />
             </div>
 
             {!connected && (
-              <div className="mt-3 text-xs text-amber-300">Connect your wallet first to create a token.</div>
+              <div className="mt-3 text-xs text-amber-600 dark:text-amber-300">Connect your wallet first to create a token.</div>
             )}
           </section>
 
-          <section id="claim" className="rounded-2xl border border-white/10 bg-white/5 p-6 shadow-xl backdrop-blur xl:col-span-4">
+          <section
+            id="claim"
+            className="rounded-2xl border border-black/10 bg-black/5 p-6 shadow-xl backdrop-blur dark:border-white/10 dark:bg-white/5 xl:col-span-4"
+          >
             <div className="mb-4 flex items-center justify-between">
               <h2 className="text-xl font-semibold">Claim tokens</h2>
             </div>
-            <div className="mb-4 flex gap-4 border-b border-white/10">
+            <div className="mb-4 flex gap-4 border-b border-black/10 dark:border-white/10">
               <button
                 onClick={() => setClaimTab("summary")}
                 className={`pb-2 text-sm ${
-                  claimTab === "summary" ? "border-b-2 border-emerald-400 text-white" : "text-zinc-400"
+                  claimTab === "summary"
+                    ? "border-b-2 border-emerald-400 text-black dark:text-white"
+                    : "text-zinc-500 dark:text-zinc-400"
                 }`}
               >
                 Summary
@@ -574,7 +585,9 @@ export default function MvpTokenApp() {
               <button
                 onClick={() => setClaimTab("table")}
                 className={`pb-2 text-sm ${
-                  claimTab === "table" ? "border-b-2 border-emerald-400 text-white" : "text-zinc-400"
+                  claimTab === "table"
+                    ? "border-b-2 border-emerald-400 text-black dark:text-white"
+                    : "text-zinc-500 dark:text-zinc-400"
                 }`}
               >
                 Claims
@@ -623,7 +636,7 @@ export default function MvpTokenApp() {
                 <RecentActivity claims={claims} />
 
                 <div className="mt-6 flex items-center justify-between">
-                  <div className="text-xs text-zinc-400">
+                  <div className="text-xs text-zinc-500 dark:text-zinc-400">
                     {tokenAddress ? (
                       `Token contract: ${tokenAddress}`
                     ) : (
@@ -650,21 +663,24 @@ export default function MvpTokenApp() {
                 </div>
 
                 {!connected && (
-                  <div className="mt-3 text-xs text-amber-300">Connect your wallet to claim tokens.</div>
+                  <div className="mt-3 text-xs text-amber-600 dark:text-amber-300">Connect your wallet to claim tokens.</div>
                 )}
-              </>
-            )}
+            </>
+          )}
 
             {claimTab === "table" && <ClaimsTable claims={claims} />}
           </section>
 
-          <section id="history" className="rounded-2xl border border-white/10 bg-white/5 p-6 shadow-xl backdrop-blur xl:col-span-4">
+          <section
+            id="history"
+            className="rounded-2xl border border-black/10 bg-black/5 p-6 shadow-xl backdrop-blur dark:border-white/10 dark:bg-white/5 xl:col-span-4"
+          >
             <div className="mb-4 flex items-center justify-between">
               <h2 className="text-xl font-semibold">History</h2>
               <div className="flex items-center gap-2">
                 <button
                   onClick={clearHistory}
-                  className="rounded-xl border border-white/10 bg-white/10 px-3 py-1.5 text-xs text-zinc-200 transition hover:bg-white/20 focus:outline-none focus:ring-2 focus:ring-white/30"
+                  className="rounded-xl border border-black/10 bg-black/10 px-3 py-1.5 text-xs text-zinc-700 transition hover:bg-black/20 focus:outline-none focus:ring-2 focus:ring-black/30 dark:border-white/10 dark:bg-white/10 dark:text-zinc-200 dark:hover:bg-white/20 dark:focus:ring-white/30"
                   aria-label="Clear history"
                   role="button"
                   tabIndex={0}
@@ -674,7 +690,7 @@ export default function MvpTokenApp() {
               </div>
             </div>
             {history.length === 0 ? (
-              <div className="text-sm text-zinc-400">No history.</div>
+              <div className="text-sm text-zinc-500 dark:text-zinc-400">No history.</div>
             ) : (
               <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
                 {history.map((item) => (
@@ -691,7 +707,7 @@ export default function MvpTokenApp() {
         </div>
       </main>
 
-      <footer className="border-t border-white/10 py-8 text-center text-xs text-zinc-400">
+      <footer className="border-t border-black/10 py-8 text-center text-xs text-zinc-500 dark:border-white/10 dark:text-zinc-400">
         MVP UI — ERC‑20 + ClaimPool focused views
       </footer>
       {claimState === "success" && txHash && (

--- a/src/components/CtaButton.jsx
+++ b/src/components/CtaButton.jsx
@@ -12,10 +12,17 @@ export default function CtaButton({ label, onClick, disabled = false, state = "i
   };
 
   const bgColors = {
-    idle: "bg-[#0d1110]",
-    loading: "bg-[#0d1110]",
+    idle: "bg-[#f0f0f0] dark:bg-[#0d1110]",
+    loading: "bg-[#f0f0f0] dark:bg-[#0d1110]",
     success: "bg-emerald-600",
     error: "bg-rose-600",
+  };
+
+  const textColors = {
+    idle: "text-black dark:text-white",
+    loading: "text-black dark:text-white",
+    success: "text-white",
+    error: "text-white",
   };
 
   return (
@@ -23,7 +30,7 @@ export default function CtaButton({ label, onClick, disabled = false, state = "i
       type="button"
       onClick={onClick}
       disabled={disabled || isLoading}
-      className={`relative isolate w-full rounded-2xl px-6 py-5 text-center font-medium text-white transition ${
+      className={`relative isolate w-full rounded-2xl px-6 py-5 text-center font-medium transition ${textColors[state]} ${
         disabled || isLoading ? "opacity-60 cursor-not-allowed" : "hover:-translate-y-0.5 active:translate-y-0"
       } focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300/40`}
       aria-label={label}

--- a/src/components/NetworkBadge.jsx
+++ b/src/components/NetworkBadge.jsx
@@ -18,7 +18,7 @@ export default function NetworkBadge({ chainId }) {
     ? LABELS[Number(chainId)] || `Chain ${chainId}`
     : "No network";
   return (
-    <span className="rounded-xl border border-white/10 bg-white/10 px-3 py-1.5 text-xs text-zinc-200">
+    <span className="rounded-xl border border-black/10 bg-black/10 px-3 py-1.5 text-xs text-zinc-700 dark:border-white/10 dark:bg-white/10 dark:text-zinc-200">
       {label}
     </span>
   );


### PR DESCRIPTION
## Summary
- add theme class and loader in index.html
- toggle and persist theme with localStorage
- provide light/dark styles for common components

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b34a8173a4832f84818c57f12ee3fc