### PR TITLE
feat: add copy button with address badges

### DIFF
--- a/src/components/ClaimsTable.jsx
+++ b/src/components/ClaimsTable.jsx
@@ -1,8 +1,6 @@
 import React, { useState, useMemo } from "react";
-
-function shorten(addr) {
-  return addr ? `${addr.slice(0, 6)}…${addr.slice(-4)}` : "";
-}
+import AddressBadge from "./AddressBadge.jsx";
+import CopyButton from "./CopyButton.jsx";
 
 export default function ClaimsTable({ claims = [] }) {
   const [sortConfig, setSortConfig] = useState({ key: "time", direction: "desc" });
@@ -42,7 +40,7 @@ export default function ClaimsTable({ claims = [] }) {
   const sortIndicator = (key) => {
     if (sortConfig.key !== key) return "";
     return sortConfig.direction === "asc" ? "↑" : "↓";
-    };
+  };
 
   return (
     <div className="mt-6">
@@ -80,7 +78,12 @@ export default function ClaimsTable({ claims = [] }) {
           ) : (
             pageData.map((c, idx) => (
               <tr key={idx} className="border-t border-white/10">
-                <td className="px-2 py-2 font-mono">{shorten(c.address)}</td>
+                <td className="px-2 py-2">
+                  <div className="flex items-center gap-2">
+                    <AddressBadge address={c.address} />
+                    <CopyButton value={c.address} />
+                  </div>
+                </td>
                 <td className="px-2 py-2">{c.amount}</td>
                 <td className="px-2 py-2">{new Date(c.time).toLocaleString()}</td>
               </tr>

--- a/src/components/CopyButton.jsx
+++ b/src/components/CopyButton.jsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { toast } from "./ToastProvider.jsx";
+
+export default function CopyButton({ value, className = "" }) {
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(value);
+      toast.success("Copied");
+    } catch (err) {
+      toast.error("Copy failed");
+    }
+  };
+
+  return (
+    <button
+      onClick={handleCopy}
+      title="Copy"
+      className={`rounded border border-white/10 bg-white/10 p-1 text-zinc-200 transition hover:bg-white/20 focus:outline-none focus:ring-2 focus:ring-white/30 ${className}`}
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        fill="none"
+        strokeWidth={1.5}
+        stroke="currentColor"
+        className="h-4 w-4"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M15.6657 3.88789C15.3991 2.94272 14.5305 2.25 13.5 2.25H10.5C9.46954 2.25 8.60087 2.94272 8.33426 3.88789M15.6657 3.88789C15.7206 4.0825 15.75 4.28782 15.75 4.5V4.5C15.75 4.91421 15.4142 5.25 15 5.25H9C8.58579 5.25 8.25 4.91421 8.25 4.5V4.5C8.25 4.28782 8.27937 4.0825 8.33426 3.88789M15.6657 3.88789C16.3119 3.93668 16.9545 3.99828 17.5933 4.07241C18.6939 4.20014 19.5 5.149 19.5 6.25699V19.5C19.5 20.7426 18.4926 21.75 17.25 21.75H6.75C5.50736 21.75 4.5 20.7426 4.5 19.5V6.25699C4.5 5.149 5.30608 4.20014 6.40668 4.07241C7.04547 3.99828 7.68808 3.93668 8.33426 3.88789"
+        />
+      </svg>
+    </button>
+  );
+}

--- a/src/components/RecentActivity.jsx
+++ b/src/components/RecentActivity.jsx
@@ -1,8 +1,6 @@
 import React from "react";
-
-function shorten(addr) {
-  return addr ? `${addr.slice(0, 6)}…${addr.slice(-4)}` : "";
-}
+import AddressBadge from "./AddressBadge.jsx";
+import CopyButton from "./CopyButton.jsx";
 
 function relativeTime(ts) {
   const diff = Math.floor((Date.now() - ts) / 1000);
@@ -28,7 +26,10 @@ export default function RecentActivity({ claims = [] }) {
             key={idx}
             className="flex items-center justify-between rounded-lg border border-white/10 bg-white/5 px-3 py-2"
           >
-            <span className="font-mono">{shorten(tx.address)}</span>
+            <div className="flex items-center gap-2">
+              <AddressBadge address={tx.address} />
+              <CopyButton value={tx.address} />
+            </div>
             <span>{tx.amount}</span>
             <span className="text-xs text-zinc-400">{relativeTime(tx.time)}</span>
           </li>

--- a/src/components/SuccessModal.jsx
+++ b/src/components/SuccessModal.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { toast } from "./ToastProvider.jsx";
+import CopyButton from "./CopyButton.jsx";
 
 export default function SuccessModal({ txHash, chainId, onClose }) {
   const explorers = {
@@ -9,28 +9,17 @@ export default function SuccessModal({ txHash, chainId, onClose }) {
   };
   const base = explorers[chainId] || "https://etherscan.io";
   const url = `${base}/tx/${txHash}`;
-
-  const copy = async () => {
-    try {
-      await navigator.clipboard.writeText(txHash);
-      toast.success("Copied");
-    } catch (err) {
-      toast.error("Copy failed");
-    }
-  };
+  const shortHash = txHash ? `${txHash.slice(0, 6)}…${txHash.slice(-4)}` : "";
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
       <div className="w-full max-w-md rounded-2xl border border-white/10 bg-white/5 p-6 text-center backdrop-blur">
         <h2 className="mb-4 text-lg font-semibold text-white">Claim successful</h2>
-        <p className="break-all text-sm text-zinc-300">{txHash}</p>
+        <div className="mb-4 flex items-center justify-center gap-2 break-all text-sm text-zinc-300">
+          <span>{shortHash}</span>
+          <CopyButton value={txHash} />
+        </div>
         <div className="mt-6 flex justify-center gap-3">
-          <button
-            onClick={copy}
-            className="rounded-md border border-white/10 bg-white/10 px-4 py-2 text-sm text-white transition hover:bg-white/20"
-          >
-            Copy
-          </button>
           <a
             href={url}
             target="_blank"

--- a/src/components/TokenSummary.jsx
+++ b/src/components/TokenSummary.jsx
@@ -1,5 +1,7 @@
 import React from "react";
 import NetworkBadge from "./NetworkBadge.jsx";
+import AddressBadge from "./AddressBadge.jsx";
+import CopyButton from "./CopyButton.jsx";
 
 const EXPLORERS = {
   1: "https://etherscan.io",
@@ -17,14 +19,6 @@ const EXPLORERS = {
 export default function TokenSummary({ tokenAddress, name, symbol, progress = 0, chainId }) {
   const explorerBase = chainId ? EXPLORERS[Number(chainId)] : null;
 
-  const handleCopy = () => {
-    if (tokenAddress) {
-      navigator?.clipboard?.writeText(tokenAddress);
-    }
-  };
-
-  const shortAddr = tokenAddress ? `${tokenAddress.slice(0, 6)}…${tokenAddress.slice(-4)}` : "";
-
   return (
     <div className="flex flex-col gap-3 rounded-2xl border border-white/10 bg-white/5 p-4">
       <div className="flex items-center justify-between">
@@ -41,13 +35,8 @@ export default function TokenSummary({ tokenAddress, name, symbol, progress = 0,
 
       {tokenAddress && (
         <div className="flex items-center gap-2 text-xs text-zinc-400">
-          <span>{shortAddr}</span>
-          <button
-            onClick={handleCopy}
-            className="rounded border border-white/10 bg-white/10 px-2 py-0.5 text-xs text-zinc-200 transition hover:bg-white/20 focus:outline-none focus:ring-2 focus:ring-white/30"
-          >
-            Copy
-          </button>
+          <AddressBadge address={tokenAddress} chainId={chainId} />
+          <CopyButton value={tokenAddress} />
           {explorerBase && (
             <a
               href={`${explorerBase}/address/${tokenAddress}`}


### PR DESCRIPTION
## Summary
- add reusable `CopyButton` component with tooltip
- show truncated addresses with identicons via `AddressBadge`
- enable copy buttons for contract, tx hash, and claim addresses

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Rollup failed to resolve import "ethereum-blockies")*

------
https://chatgpt.com/codex/tasks/task_e_68b34f584834832fb6bacd23018555de