### PR TITLE
Improve accessibility and add responsive testing

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+src/components/__tests__/

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,18 @@
+module.exports = {
+  env: {
+    browser: true,
+    es2021: true,
+  },
+  extends: ['eslint:recommended', 'plugin:jsx-a11y/recommended'],
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+  plugins: ['jsx-a11y'],
+  rules: {
+    'no-unused-vars': 'off',
+  },
+};

--- a/README.md
+++ b/README.md
@@ -16,3 +16,18 @@ npm run preview
 ```
 
 > Note: This is a UI-only mock. Wallet/contract wiring (wagmi/RainbowKit + TokenFactory) can be added next.
+
+## Testing
+
+Run basic accessibility linting and responsive tests:
+
+```bash
+npm run lint
+npm test
+```
+
+### Manual test
+
+1. Run `npm run dev` and open the app.
+2. Set the browser width to 360 px.
+3. Verify that the page does not scroll horizontally (no `overflow-x`).

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "lint": "eslint src/components --ext .js,.jsx",
+    "test": "vitest"
   },
   "dependencies": {
     "@openzeppelin/contracts": "^5.0.0",
@@ -21,6 +23,12 @@
     "autoprefixer": "^10.4.19",
     "postcss": "^8.4.38",
     "tailwindcss": "^3.4.7",
-    "vite": "^5.3.0"
+    "vite": "^5.3.0",
+    "eslint": "^8.57.0",
+    "eslint-plugin-jsx-a11y": "^6.8.0",
+    "vitest": "^1.6.0",
+    "jsdom": "^24.0.0",
+    "@testing-library/react": "^14.2.0",
+    "@testing-library/jest-dom": "^6.4.0"
   }
 }

--- a/src/components/ClaimsTable.jsx
+++ b/src/components/ClaimsTable.jsx
@@ -52,19 +52,68 @@ export default function ClaimsTable({ claims = [] }) {
           setPage(1);
         }}
         placeholder="Filter by address"
-        className="mb-2 w-full rounded border border-white/10 bg-white/10 px-2 py-1 text-sm text-zinc-200 placeholder-zinc-500"
+        aria-label="Filter by address"
+        className="mb-2 w-full rounded border border-white/10 bg-white/10 px-2 py-1 text-sm text-zinc-200 placeholder-zinc-500 focus:outline-none focus:ring-2 focus:ring-white/30"
       />
       <table className="min-w-full text-sm">
         <thead>
           <tr className="text-left text-zinc-300">
-            <th className="cursor-pointer px-2 py-1" onClick={() => requestSort("address")}>
-              Address {sortIndicator("address")}
+            <th
+              scope="col"
+              aria-sort={
+                sortConfig.key === "address"
+                  ? sortConfig.direction === "asc"
+                    ? "ascending"
+                    : "descending"
+                  : "none"
+              }
+              className="px-2 py-1"
+            >
+              <button
+                type="button"
+                onClick={() => requestSort("address")}
+                className="flex items-center gap-1 focus:outline-none focus:ring-2 focus:ring-white/30"
+              >
+                Address {sortIndicator("address")}
+              </button>
             </th>
-            <th className="cursor-pointer px-2 py-1" onClick={() => requestSort("amount")}>
-              Amount {sortIndicator("amount")}
+            <th
+              scope="col"
+              aria-sort={
+                sortConfig.key === "amount"
+                  ? sortConfig.direction === "asc"
+                    ? "ascending"
+                    : "descending"
+                  : "none"
+              }
+              className="px-2 py-1"
+            >
+              <button
+                type="button"
+                onClick={() => requestSort("amount")}
+                className="flex items-center gap-1 focus:outline-none focus:ring-2 focus:ring-white/30"
+              >
+                Amount {sortIndicator("amount")}
+              </button>
             </th>
-            <th className="cursor-pointer px-2 py-1" onClick={() => requestSort("time")}>
-              Time {sortIndicator("time")}
+            <th
+              scope="col"
+              aria-sort={
+                sortConfig.key === "time"
+                  ? sortConfig.direction === "asc"
+                    ? "ascending"
+                    : "descending"
+                  : "none"
+              }
+              className="px-2 py-1"
+            >
+              <button
+                type="button"
+                onClick={() => requestSort("time")}
+                className="flex items-center gap-1 focus:outline-none focus:ring-2 focus:ring-white/30"
+              >
+                Time {sortIndicator("time")}
+              </button>
             </th>
           </tr>
         </thead>
@@ -95,7 +144,7 @@ export default function ClaimsTable({ claims = [] }) {
         <button
           onClick={() => setPage((p) => Math.max(1, p - 1))}
           disabled={page === 1}
-          className="rounded border border-white/10 bg-white/10 px-3 py-1.5 disabled:opacity-50"
+          className="rounded border border-white/10 bg-white/10 px-3 py-1.5 disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-white/30"
         >
           Previous
         </button>
@@ -105,7 +154,7 @@ export default function ClaimsTable({ claims = [] }) {
         <button
           onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
           disabled={page === totalPages}
-          className="rounded border border-white/10 bg-white/10 px-3 py-1.5 disabled:opacity-50"
+          className="rounded border border-white/10 bg-white/10 px-3 py-1.5 disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-white/30"
         >
           Next
         </button>

--- a/src/components/CopyButton.jsx
+++ b/src/components/CopyButton.jsx
@@ -15,6 +15,7 @@ export default function CopyButton({ value, className = "" }) {
     <button
       onClick={handleCopy}
       title="Copy"
+      aria-label="Copy to clipboard"
       className={`rounded border border-white/10 bg-white/10 p-1 text-zinc-200 transition hover:bg-white/20 focus:outline-none focus:ring-2 focus:ring-white/30 ${className}`}
     >
       <svg

--- a/src/components/CtaButton.jsx
+++ b/src/components/CtaButton.jsx
@@ -34,8 +34,6 @@ export default function CtaButton({ label, onClick, disabled = false, state = "i
         disabled || isLoading ? "opacity-60 cursor-not-allowed" : "hover:-translate-y-0.5 active:translate-y-0"
       } focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300/40`}
       aria-label={label}
-      role="button"
-      tabIndex={0}
     >
       <span
         className={`absolute inset-0 -z-10 rounded-2xl ${bgColors[state]} shadow-[0_12px_24px_rgba(16,185,129,0.12)]`}

--- a/src/components/SuccessModal.jsx
+++ b/src/components/SuccessModal.jsx
@@ -12,7 +12,7 @@ export default function SuccessModal({ txHash, chainId, onClose }) {
   const shortHash = txHash ? `${txHash.slice(0, 6)}…${txHash.slice(-4)}` : "";
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60" role="dialog" aria-modal="true">
       <div className="w-full max-w-md rounded-2xl border border-white/10 bg-white/5 p-6 text-center backdrop-blur">
         <h2 className="mb-4 text-lg font-semibold text-white">Claim successful</h2>
         <div className="mb-4 flex items-center justify-center gap-2 break-all text-sm text-zinc-300">
@@ -24,14 +24,14 @@ export default function SuccessModal({ txHash, chainId, onClose }) {
             href={url}
             target="_blank"
             rel="noopener noreferrer"
-            className="rounded-md border border-emerald-500 bg-emerald-600 px-4 py-2 text-sm text-white transition hover:bg-emerald-500"
+            className="rounded-md border border-emerald-500 bg-emerald-600 px-4 py-2 text-sm text-white transition hover:bg-emerald-500 focus:outline-none focus:ring-2 focus:ring-white/30"
           >
             Open in explorer
           </a>
         </div>
         <button
           onClick={onClose}
-          className="mt-6 text-sm text-zinc-400 transition hover:text-white"
+          className="mt-6 text-sm text-zinc-400 transition hover:text-white focus:outline-none focus:ring-2 focus:ring-white/30"
         >
           Close
         </button>

--- a/src/components/TokenSummary.jsx
+++ b/src/components/TokenSummary.jsx
@@ -42,7 +42,7 @@ export default function TokenSummary({ tokenAddress, name, symbol, progress = 0,
               href={`${explorerBase}/address/${tokenAddress}`}
               target="_blank"
               rel="noopener noreferrer"
-              className="text-emerald-400 hover:underline"
+              className="text-emerald-400 hover:underline focus:outline-none focus:ring-2 focus:ring-emerald-400/50"
             >
               Explorer
             </a>

--- a/src/components/__tests__/responsive.test.jsx
+++ b/src/components/__tests__/responsive.test.jsx
@@ -1,0 +1,17 @@
+import { render } from '@testing-library/react';
+import TokenSummary from '../TokenSummary.jsx';
+import { describe, it, expect } from 'vitest';
+
+// basic layout check at small viewport width
+
+describe('responsive layout', () => {
+  it('fits within 360px without horizontal overflow', () => {
+    const { container } = render(
+      <div style={{ width: 360 }}>
+        <TokenSummary name="Sample" symbol="SMP" progress={50} />
+      </div>
+    );
+    const root = container.firstChild;
+    expect(root.scrollWidth).toBeLessThanOrEqual(360);
+  });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./vitest.setup.js'],
+  },
+});

--- a/vitest.setup.js
+++ b/vitest.setup.js
@@ -1,0 +1,4 @@
+import { expect } from 'vitest';
+import * as matchers from '@testing-library/jest-dom/matchers';
+
+expect.extend(matchers);


### PR DESCRIPTION
## Summary
- add aria-labels, roles, and focus rings across components
- introduce eslint with jsx-a11y plugin and responsive layout test at 360px
- document manual 360px check and add lint/test scripts

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3509a71a0832fa15e47f15b630804