### PR TITLE
feat: add reusable Input component and tests

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,6 +12,7 @@ import Spinner from "./components/Spinner.jsx";
 import { toast } from "./components/ToastProvider.jsx";
 import RecentActivity from "./components/RecentActivity.jsx";
 import ClaimsTable from "./components/ClaimsTable.jsx";
+import Input from "./components/Input.jsx";
 
 // MVP single-file UI mock (no blockchain wired yet)
 // Tailwind only. Dark theme, simple modern buttons.
@@ -486,9 +487,8 @@ export default function MvpTokenApp() {
             <div className="grid gap-4">
               <div>
                 <label className="mb-1 block text-sm text-zinc-300">Name *</label>
-                <input
+                <Input
                   ref={nameRef}
-                  className="w-full rounded-xl border border-white/10 bg-black/40 px-3 py-2 text-white outline-none placeholder:text-zinc-500 focus:ring-2 focus:ring-emerald-400/30"
                   placeholder="e.g. WalkCoin"
                   value={name}
                   onChange={(e) => setName(e.target.value)}
@@ -496,8 +496,8 @@ export default function MvpTokenApp() {
               </div>
               <div>
                 <label className="mb-1 block text-sm text-zinc-300">Symbol *</label>
-                <input
-                  className="w-full rounded-xl border border-white/10 bg-black/40 px-3 py-2 uppercase text-white outline-none placeholder:text-zinc-500 focus:ring-2 focus:ring-emerald-400/30"
+                <Input
+                  className="uppercase"
                   placeholder="e.g. WLK"
                   value={symbol}
                   onChange={(e) => setSymbol(e.target.value.slice(0, 11))}
@@ -506,8 +506,7 @@ export default function MvpTokenApp() {
               <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-2">
                 <div>
                 <label className="mb-1 block text-sm text-zinc-300">Author *</label>
-                <input
-                    className="w-full rounded-xl border border-white/10 bg-black/40 px-3 py-2 text-white outline-none placeholder:text-zinc-500 focus:ring-2 focus:ring-emerald-400/30"
+                <Input
                     placeholder="Your name or address"
                     value={author}
                     onChange={(e) => setAuthor(e.target.value)}
@@ -524,8 +523,9 @@ export default function MvpTokenApp() {
               </div>
               <div>
                 <label className="mb-1 block text-sm text-zinc-300">Description *</label>
-                <textarea
-                  className="min-h-[96px] w-full rounded-xl border border-white/10 bg-black/40 px-3 py-2 text-white outline-none placeholder:text-zinc-500 focus:ring-2 focus:ring-emerald-400/30"
+                <Input
+                  as="textarea"
+                  className="min-h-[96px]"
                   placeholder="Short description of the token and its purpose…"
                   value={description}
                   onChange={(e) => setDescription(e.target.value)}

--- a/src/components/Input.jsx
+++ b/src/components/Input.jsx
@@ -1,0 +1,12 @@
+import React, { forwardRef } from "react";
+
+const Input = forwardRef(function Input(
+  { as: Component = "input", className = "", ...props },
+  ref
+) {
+  const baseClasses =
+    "w-full rounded-xl border border-black/10 bg-white/5 px-3 py-2 text-black outline-none placeholder:text-zinc-500 focus:ring-2 focus:ring-emerald-400/30 dark:border-white/10 dark:bg-black/40 dark:text-white";
+  return <Component ref={ref} className={`${baseClasses} ${className}`} {...props} />;
+});
+
+export default Input;

--- a/src/components/__tests__/Input.test.jsx
+++ b/src/components/__tests__/Input.test.jsx
@@ -1,0 +1,26 @@
+import { render } from '@testing-library/react';
+import Input from '../Input.jsx';
+import { describe, it, expect } from 'vitest';
+
+// simple verification of default styling and textarea support
+
+describe('Input', () => {
+  it('renders input with default classes', () => {
+    const { container } = render(<Input />);
+    const input = container.firstChild;
+    expect(input.tagName).toBe('INPUT');
+    expect(input).toHaveClass(
+      'rounded-xl',
+      'border',
+      'border-black/10',
+      'dark:border-white/10'
+    );
+  });
+
+  it('supports textarea and class overrides', () => {
+    const { container } = render(<Input as="textarea" className="min-h-[96px]" />);
+    const textarea = container.firstChild;
+    expect(textarea.tagName).toBe('TEXTAREA');
+    expect(textarea).toHaveClass('min-h-[96px]');
+  });
+});


### PR DESCRIPTION
## Summary
- add reusable `<Input>` component with default styling
- replace form fields in App.jsx to use `<Input>` with minimal overrides
- add unit tests for Input component

## Testing
- `npm run lint`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68b424b87cd0832facf7b7506ea3935e