### PR TITLE
Add referral invites and leaderboard

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,6 +14,8 @@ import RecentActivity from "./components/RecentActivity.jsx";
 import ClaimsTable from "./components/ClaimsTable.jsx";
 import Input from "./components/Input.jsx";
 import Stat from "./components/Stat.jsx";
+import InviteModal from "./components/InviteModal.jsx";
+import Leaderboard from "./components/Leaderboard.jsx";
 
 // MVP single-file UI mock (no blockchain wired yet)
 // Tailwind only. Dark theme, simple modern buttons.
@@ -195,6 +197,7 @@ export default function MvpTokenApp() {
   const [claimState, setClaimState] = useState("idle");
   const [createState, setCreateState] = useState("idle");
   const [txHash, setTxHash] = useState(null);
+  const [inviteOpen, setInviteOpen] = useState(false);
 
   const nameRef = useRef(null);
 
@@ -806,6 +809,7 @@ export default function MvpTokenApp() {
                 </div>
 
                 <RecentActivity activity={activity} />
+                <Leaderboard />
 
                 <div className="mt-6 flex items-center justify-between">
                   <div className="text-xs text-zinc-400">
@@ -833,6 +837,15 @@ export default function MvpTokenApp() {
                 {!connected && (
                   <div className="mt-3 text-xs text-amber-300">Connect your wallet to claim tokens.</div>
                 )}
+
+                <div className="mt-4 text-right">
+                  <button
+                    onClick={() => setInviteOpen(true)}
+                    className="rounded-xl border border-white/10 bg-white/10 px-3 py-1.5 text-xs text-zinc-200 transition hover:bg-white/20 focus:outline-none focus:ring-2 focus:ring-white/30"
+                  >
+                    Invite to claim
+                  </button>
+                </div>
             </>
           )}
 
@@ -875,8 +888,14 @@ export default function MvpTokenApp() {
         </section>
       </main>
       {claimState === "success" && txHash && (
-        <SuccessModal txHash={txHash} chainId={chainId} onClose={closeModal} />
+        <SuccessModal
+          txHash={txHash}
+          chainId={chainId}
+          onClose={closeModal}
+          onInvite={() => setInviteOpen(true)}
+        />
       )}
+      {inviteOpen && <InviteModal onClose={() => setInviteOpen(false)} />}
     </div>
   );
 }

--- a/src/components/InviteModal.jsx
+++ b/src/components/InviteModal.jsx
@@ -1,0 +1,98 @@
+import React from "react";
+import { toast } from "./ToastProvider.jsx";
+
+function getStoredRef() {
+  try {
+    const raw = localStorage.getItem("referral");
+    if (!raw) return null;
+    const data = JSON.parse(raw);
+    if (data.expiry && data.expiry > Date.now()) {
+      return data.value;
+    }
+    localStorage.removeItem("referral");
+  } catch (e) {
+    // ignore
+  }
+  return null;
+}
+
+function incrementInviteCount() {
+  const key = "ref.invites";
+  const count = parseInt(localStorage.getItem(key) || "0", 10) + 1;
+  localStorage.setItem(key, count);
+}
+
+export default function InviteModal({ onClose }) {
+  const ref = getStoredRef();
+  const base = window.location.origin;
+  const link = ref ? `${base}?ref=${encodeURIComponent(ref)}` : base;
+  const encoded = encodeURIComponent(link);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(link);
+      toast.success("Copied");
+      incrementInviteCount();
+    } catch (err) {
+      toast.error("Copy failed");
+    }
+  };
+
+  const handleShare = () => {
+    incrementInviteCount();
+  };
+
+  const handleDiscord = () => {
+    navigator.clipboard.writeText(link).catch(() => {});
+    handleShare();
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60" role="dialog" aria-modal="true">
+      <div className="w-full max-w-md rounded-2xl border border-white/10 bg-white/5 p-6 text-center backdrop-blur">
+        <h2 className="mb-4 text-lg font-semibold text-white">Invite friends</h2>
+        <div className="flex flex-col gap-3">
+          <a
+            href={`https://x.com/intent/tweet?url=${encoded}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={handleShare}
+            className="rounded-md border border-white/10 bg-white/10 px-4 py-2 text-sm text-white transition hover:bg-white/20"
+          >
+            Share on X
+          </a>
+          <a
+            href={`https://t.me/share/url?url=${encoded}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={handleShare}
+            className="rounded-md border border-white/10 bg-white/10 px-4 py-2 text-sm text-white transition hover:bg-white/20"
+          >
+            Share on Telegram
+          </a>
+          <a
+            href="https://discord.com/channels/@me"
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={handleDiscord}
+            className="rounded-md border border-white/10 bg-white/10 px-4 py-2 text-sm text-white transition hover:bg-white/20"
+          >
+            Share on Discord
+          </a>
+          <button
+            onClick={handleCopy}
+            className="rounded-md border border-white/10 bg-white/10 px-4 py-2 text-sm text-white transition hover:bg-white/20"
+          >
+            Copy link
+          </button>
+        </div>
+        <button
+          onClick={onClose}
+          className="mt-6 text-sm text-zinc-400 transition hover:text-white focus:outline-none focus:ring-2 focus:ring-white/30"
+        >
+          Close
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Leaderboard.jsx
+++ b/src/components/Leaderboard.jsx
@@ -1,0 +1,52 @@
+import React, { useEffect, useState } from "react";
+
+export default function Leaderboard() {
+  const [leaders, setLeaders] = useState(null);
+
+  useEffect(() => {
+    let active = true;
+    fetch("/api/leaderboard")
+      .then((res) => res.json())
+      .then((data) => {
+        if (!active) return;
+        if (Array.isArray(data) && data.length > 0) {
+          setLeaders(data);
+        } else if (data && Array.isArray(data.leaders) && data.leaders.length > 0) {
+          setLeaders(data.leaders);
+        }
+      })
+      .catch(() => {});
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const localCount = parseInt(localStorage.getItem("ref.invites") || "0", 10);
+
+  if (leaders) {
+    return (
+      <div className="mt-6 rounded-2xl border border-white/10 bg-white/5 p-6">
+        <h3 className="mb-2 text-lg font-semibold text-white">Top referrers</h3>
+        <ol className="space-y-1 text-sm text-zinc-300">
+          {leaders.map((item, idx) => (
+            <li key={idx} className="flex justify-between">
+              <span className="mr-2">
+                {idx + 1}. {item.name || item.address}
+              </span>
+              <span>{item.count}</span>
+            </li>
+          ))}
+        </ol>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-6 rounded-2xl border border-white/10 bg-white/5 p-6 text-sm text-zinc-300">
+      <div className="mb-2 font-semibold text-white">Your invites</div>
+      <div>
+        You have invited {localCount} {localCount === 1 ? "friend" : "friends"}.
+      </div>
+    </div>
+  );
+}

--- a/src/components/SuccessModal.jsx
+++ b/src/components/SuccessModal.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import CopyButton from "./CopyButton.jsx";
 
-export default function SuccessModal({ txHash, chainId, onClose }) {
+export default function SuccessModal({ txHash, chainId, onClose, onInvite = () => {} }) {
   const explorers = {
     1: "https://etherscan.io",
     5: "https://goerli.etherscan.io",
@@ -28,6 +28,12 @@ export default function SuccessModal({ txHash, chainId, onClose }) {
           >
             Open in explorer
           </a>
+          <button
+            onClick={onInvite}
+            className="rounded-md border border-white/10 bg-white/10 px-4 py-2 text-sm text-white transition hover:bg-white/20 focus:outline-none focus:ring-2 focus:ring-white/30"
+          >
+            Invite to claim
+          </button>
         </div>
         <button
           onClick={onClose}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,6 +4,14 @@ import App from './App.jsx'
 import './index.css'
 import ToastProvider from './components/ToastProvider.jsx'
 
+// Store referral code from URL in localStorage with 30-day expiry
+const params = new URLSearchParams(window.location.search)
+const ref = params.get('ref')
+if (ref) {
+  const data = { value: ref, expiry: Date.now() + 30 * 24 * 60 * 60 * 1000 }
+  localStorage.setItem('referral', JSON.stringify(data))
+}
+
 const root = createRoot(document.getElementById('root'))
 root.render(
   <ToastProvider>


### PR DESCRIPTION
## Summary
- parse referral codes from the URL and cache them in localStorage
- implement InviteModal with social share and copy options
- add Leaderboard component with API fallback to local invite count
- wire up invite actions across dashboard and success screen

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4a36c5260832f825e05fab75053bd