### PR TITLE
Add sticky mobile CTA and wallet watch asset integration

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,6 +14,7 @@ import RecentActivity from "./components/RecentActivity.jsx";
 import ClaimsTable from "./components/ClaimsTable.jsx";
 import Input from "./components/Input.jsx";
 import Stat from "./components/Stat.jsx";
+import StickyCTA from "./components/StickyCTA.jsx";
 
 // MVP single-file UI mock (no blockchain wired yet)
 // Tailwind only. Dark theme, simple modern buttons.
@@ -538,6 +539,27 @@ export default function MvpTokenApp() {
     }
   };
 
+  const addTokenToWallet = async () => {
+    if (!window.ethereum || !tokenAddress) return;
+    try {
+      await window.ethereum.request({
+        method: "wallet_watchAsset",
+        params: {
+          type: "ERC20",
+          options: {
+            address: tokenAddress,
+            symbol: symbol || "TKN",
+            decimals: 18,
+          },
+        },
+      });
+      toast.success("Token added to wallet");
+    } catch (err) {
+      console.error("Add token failed", err);
+      toast.error("Add token failed");
+    }
+  };
+
   return (
     <div className="min-h-screen bg-background text-foreground">
       <BackgroundFX />
@@ -756,6 +778,7 @@ export default function MvpTokenApp() {
                       symbol={sampleToken.symbol}
                       progress={Math.round(((TOTAL - remaining) / TOTAL) * 100)}
                       chainId={chainId}
+                      onAddToken={addTokenToWallet}
                     />
 
                     <EligibilityInfo
@@ -877,6 +900,11 @@ export default function MvpTokenApp() {
       {claimState === "success" && txHash && (
         <SuccessModal txHash={txHash} chainId={chainId} onClose={closeModal} />
       )}
+      <StickyCTA
+        onClick={connected ? doClaim : connectWallet}
+        disabled={connected ? !tokenAddress || remaining === 0 : false}
+        state={connected ? claimState : "idle"}
+      />
     </div>
   );
 }

--- a/src/components/ClaimsTable.jsx
+++ b/src/components/ClaimsTable.jsx
@@ -1,5 +1,4 @@
 import React, { useState, useMemo } from "react";
-import AddressBadge from "./AddressBadge.jsx";
 import CopyButton from "./CopyButton.jsx";
 
 export default function ClaimsTable({ claims = [] }) {
@@ -128,10 +127,7 @@ export default function ClaimsTable({ claims = [] }) {
             pageData.map((c, idx) => (
               <tr key={idx} className="border-t border-white/10">
                 <td className="px-2 py-2">
-                  <div className="flex items-center gap-2">
-                    <AddressBadge address={c.address} />
-                    <CopyButton value={c.address} />
-                  </div>
+                  <CopyButton value={c.address} />
                 </td>
                 <td className="px-2 py-2">{c.amount}</td>
                 <td className="px-2 py-2">{new Date(c.time).toLocaleString()}</td>

--- a/src/components/CopyButton.jsx
+++ b/src/components/CopyButton.jsx
@@ -1,11 +1,16 @@
 import React from "react";
 import { toast } from "./ToastProvider.jsx";
 
+function shorten(value) {
+  if (!value) return "";
+  return `${value.slice(0, 6)}…${value.slice(-4)}`;
+}
+
 export default function CopyButton({ value, className = "" }) {
   const handleCopy = async () => {
     try {
       await navigator.clipboard.writeText(value);
-      toast.success("Copied");
+      toast.success("Skopiowano!");
     } catch (err) {
       toast.error("Copy failed");
     }
@@ -14,10 +19,11 @@ export default function CopyButton({ value, className = "" }) {
   return (
     <button
       onClick={handleCopy}
-      title="Copy"
+      title={value}
       aria-label="Copy to clipboard"
-      className={`rounded border border-white/10 bg-white/10 p-1 text-zinc-200 transition hover:bg-white/20 focus:outline-none focus:ring-2 focus:ring-white/30 ${className}`}
+      className={`flex items-center gap-1 rounded-xl border border-white/10 bg-white/10 px-2 py-1 text-xs text-zinc-200 transition hover:bg-white/20 focus:outline-none focus:ring-2 focus:ring-white/30 ${className}`}
     >
+      <span className="font-mono">{shorten(value)}</span>
       <svg
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 24 24"
@@ -25,6 +31,7 @@ export default function CopyButton({ value, className = "" }) {
         strokeWidth={1.5}
         stroke="currentColor"
         className="h-4 w-4"
+        aria-hidden="true"
       >
         <path
           strokeLinecap="round"

--- a/src/components/StickyCTA.jsx
+++ b/src/components/StickyCTA.jsx
@@ -1,0 +1,14 @@
+import React from "react";
+import CtaButton from "./CtaButton.jsx";
+
+export default function StickyCTA({ onClick, disabled = false, state = "idle" }) {
+  return (
+    <>
+      {/* Reserve space to avoid layout shift */}
+      <div className="h-24 md:hidden" aria-hidden="true" />
+      <div className="fixed bottom-0 left-0 right-0 border-t border-white/10 bg-black/80 p-4 backdrop-blur md:hidden">
+        <CtaButton label="Connect & Claim" onClick={onClick} disabled={disabled} state={state} />
+      </div>
+    </>
+  );
+}

--- a/src/components/TokenSummary.jsx
+++ b/src/components/TokenSummary.jsx
@@ -1,6 +1,5 @@
 import React from "react";
 import NetworkBadge from "./NetworkBadge.jsx";
-import AddressBadge from "./AddressBadge.jsx";
 import CopyButton from "./CopyButton.jsx";
 
 const EXPLORERS = {
@@ -16,7 +15,7 @@ const EXPLORERS = {
   11155111: "https://sepolia.etherscan.io",
 };
 
-export default function TokenSummary({ tokenAddress, name, symbol, progress = 0, chainId }) {
+export default function TokenSummary({ tokenAddress, name, symbol, progress = 0, chainId, onAddToken }) {
   const explorerBase = chainId ? EXPLORERS[Number(chainId)] : null;
 
   return (
@@ -35,7 +34,6 @@ export default function TokenSummary({ tokenAddress, name, symbol, progress = 0,
 
       {tokenAddress && (
         <div className="flex items-center gap-2 text-xs text-zinc-400">
-          <AddressBadge address={tokenAddress} chainId={chainId} />
           <CopyButton value={tokenAddress} />
           {explorerBase && (
             <a
@@ -46,6 +44,14 @@ export default function TokenSummary({ tokenAddress, name, symbol, progress = 0,
             >
               Explorer
             </a>
+          )}
+          {onAddToken && (
+            <button
+              onClick={onAddToken}
+              className="text-emerald-400 hover:underline focus:outline-none focus:ring-2 focus:ring-emerald-400/50"
+            >
+              Add to wallet
+            </button>
           )}
         </div>
       )}


### PR DESCRIPTION
## Summary
- add sticky mobile footer with "Connect & Claim" button and reserved layout space
- enable MetaMask `wallet_watchAsset` for one-click token import
- add CopyButton that shortens addresses and shows "Skopiowano!" toast

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4a374c394832f829c20bc21687bf4